### PR TITLE
Added unit tests for impute_sdtm function #32

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,10 @@ Suggests:
     admiral.test,
     devtools,
     pkgdown,
-    testthat,
+    testthat (>= 3.0.0),
     knitr,
     rmarkdown,
     roxygen2,
     usethis
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/R/impute_sdtm.R
+++ b/R/impute_sdtm.R
@@ -21,18 +21,18 @@ impute_sdtm <- function(dsin, varin, varout){
 
   # Handle input values for use in tidyverse
   varin <- enquo(varin)
-  varout <- dplyr::quo_name(enquo(varout))
+  varout <- quo_name(enquo(varout))
 
   # Impute character SDTM dates and convert to datetime object
   out <- dsin %>%
     mutate(TEMP_DTC = case_when(
-      nchar(!!varin) == 0 ~ "",
-      nchar(!!varin) == 4 ~ paste0(trimws(!!varin), "-01-01T00:00:00"),
-      nchar(!!varin) == 7 ~ paste0(trimws(!!varin), "-01T00:00:00"),
-      nchar(!!varin) == 10 ~ paste0(trimws(!!varin), "T00:00:00"),
-      nchar(!!varin) == 13 ~ paste0(trimws(!!varin), ":00:00"),
-      nchar(!!varin) == 16 ~ paste0(trimws(!!varin), ":00"),
-      nchar(!!varin) == 19 ~ !!varin,
+      nchar(as.character(!!varin)) == 0 ~ "",
+      nchar(as.character(!!varin)) == 4 ~ paste0(trimws(as.character(!!varin)), "-01-01T00:00:00"),
+      nchar(as.character(!!varin)) == 7 ~ paste0(trimws(as.character(!!varin)), "-01T00:00:00"),
+      nchar(as.character(!!varin)) == 10 ~ paste0(trimws(as.character(!!varin)), "T00:00:00"),
+      nchar(as.character(!!varin)) == 13 ~ paste0(trimws(as.character(!!varin)), ":00:00"),
+      nchar(as.character(!!varin)) == 16 ~ paste0(trimws(as.character(!!varin)), ":00"),
+      nchar(as.character(!!varin)) == 19 ~ as.character(!!varin),
       TRUE ~ ""
     )) %>%
     mutate(!!varout := ymd_hms(TEMP_DTC))

--- a/tests/testthat/test-impute_sdtm.R
+++ b/tests/testthat/test-impute_sdtm.R
@@ -41,7 +41,7 @@ expected3 <- data.frame(USUBJID = rep(c("U1234567"), 7),
                         EXSTDTC = c("2022-08-10T15:13:301", "2022-08-10T15:13:", "2022-08-10T15:", "2022-08-10T", "2022-08-", "2022-", ""),
                         DCUT_TEMP_EXSTDTC = ymd_hms(rep(c(""), 7)))
 
-test_that("Dates in incorrect format or missing dates are set to NA", {
+test_that("Dates in incorrect format or missing dates are always set to NA", {
   expect_equal(
     impute_sdtm(dsin=input3, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
     expected3

--- a/tests/testthat/test-impute_sdtm.R
+++ b/tests/testthat/test-impute_sdtm.R
@@ -1,0 +1,34 @@
+### Set up input data and expected results ###
+input <- data.frame(USUBJID = rep(c("U1234567"), 7),
+                    EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022", ""))
+
+expected <- data.frame(USUBJID = rep(c("U1234567"), 7),
+                       EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022", ""),
+                       DCUT_TEMP_EXSTDTC = ymd_hms(c("2022-08-10T15:13:30", "2022-08-10T15:13:00", "2022-08-10T15:00:00", "2022-08-10T00:00:00",
+                                                     "2022-08-01T00:00:00", "2022-01-01T00:00:00", "")))
+
+### Test with factor input ###
+input1 <- input %>%
+  mutate(EXSTDTC = as.factor(EXSTDTC))
+expected1 <- expected %>%
+  mutate(EXSTDTC = as.factor(EXSTDTC))
+
+test_that("Imputation of SDTM variables is working correctly when input variable is factor", {
+  expect_equal(
+    impute_sdtm(dsin=input1, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
+    expected1
+  )
+})
+
+### Test with character input ###
+input2 <- input %>%
+  mutate(EXSTDTC = as.character(EXSTDTC))
+expected2 <- expected %>%
+  mutate(EXSTDTC = as.character(EXSTDTC))
+
+test_that("Imputation of SDTM variables is working correctly when input variable is character", {
+  expect_equal(
+    impute_sdtm(dsin=input2, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
+    expected2
+  )
+})

--- a/tests/testthat/test-impute_sdtm.R
+++ b/tests/testthat/test-impute_sdtm.R
@@ -1,11 +1,11 @@
 ### Set up input data and expected results ###
-input <- data.frame(USUBJID = rep(c("U1234567"), 7),
-                    EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022", ""))
+input <- data.frame(USUBJID = rep(c("U1234567"), 6),
+                    EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022"))
 
-expected <- data.frame(USUBJID = rep(c("U1234567"), 7),
-                       EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022", ""),
+expected <- data.frame(USUBJID = rep(c("U1234567"), 6),
+                       EXSTDTC = c("2022-08-10T15:13:30", "2022-08-10T15:13", "2022-08-10T15", "2022-08-10", "2022-08", "2022"),
                        DCUT_TEMP_EXSTDTC = ymd_hms(c("2022-08-10T15:13:30", "2022-08-10T15:13:00", "2022-08-10T15:00:00", "2022-08-10T00:00:00",
-                                                     "2022-08-01T00:00:00", "2022-01-01T00:00:00", "")))
+                                                     "2022-08-01T00:00:00", "2022-01-01T00:00:00")))
 
 ### Test with factor input ###
 input1 <- input %>%
@@ -13,7 +13,7 @@ input1 <- input %>%
 expected1 <- expected %>%
   mutate(EXSTDTC = as.factor(EXSTDTC))
 
-test_that("Imputation of SDTM variables is working correctly when input variable is factor", {
+test_that("Imputation of SDTM variables is working correctly when input variable is factor and dates in correct format", {
   expect_equal(
     impute_sdtm(dsin=input1, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
     expected1
@@ -26,9 +26,24 @@ input2 <- input %>%
 expected2 <- expected %>%
   mutate(EXSTDTC = as.character(EXSTDTC))
 
-test_that("Imputation of SDTM variables is working correctly when input variable is character", {
+test_that("Imputation of SDTM variables is working correctly when input variable is character and dates in correct format", {
   expect_equal(
     impute_sdtm(dsin=input2, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
     expected2
+  )
+})
+
+### Test with input dates in incorrect formats ###
+input3 <- data.frame(USUBJID = rep(c("U1234567"), 7),
+                     EXSTDTC = c("2022-08-10T15:13:301", "2022-08-10T15:13:", "2022-08-10T15:", "2022-08-10T", "2022-08-", "2022-", ""))
+
+expected3 <- data.frame(USUBJID = rep(c("U1234567"), 7),
+                        EXSTDTC = c("2022-08-10T15:13:301", "2022-08-10T15:13:", "2022-08-10T15:", "2022-08-10T", "2022-08-", "2022-", ""),
+                        DCUT_TEMP_EXSTDTC = ymd_hms(rep(c(""), 7)))
+
+test_that("Dates in incorrect format or missing dates are set to NA", {
+  expect_equal(
+    impute_sdtm(dsin=input3, varin=EXSTDTC, varout=DCUT_TEMP_EXSTDTC),
+    expected3
   )
 })


### PR DESCRIPTION
Added unit tests for impute_sdtm function as per issue #32. I am merging this to devel so that @alanaharris22 and @barnett11 can use this function within their own code. This function is NOT final.