### PR TITLE
Replace set-output

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Set coverage percentage as output
         id: set-coverage-percentage
-        run: echo "::set-output name=coverage-percentage::$(cat coverage.txt)"
+        run: echo "coverage-percentage=$(cat coverage.txt)" >> $GITHUB_OUTPUT
         if: steps.check_coverage_reports.outputs.files_exists == 'true'
 
       - name: Generate Coverage Summary Report


### PR DESCRIPTION
This PR follows a [recommendation by GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) to change the way outputs are set in GitHub Actions and Workflows.

The old way of setting the outputs will become unsupported in 2023.