### PR TITLE
Updated process_cut() function to add default values to the patient_c…

### DIFF
--- a/R/process_cut.R
+++ b/R/process_cut.R
@@ -47,15 +47,14 @@
 #'   cut_var = DCUTDTM,
 #'   special_dm = FALSE
 #' )
-
+#'
 process_cut <- function(source_sdtm_data,
                         patient_cut_v = vector(),
-                        date_cut_m = matrix(nrow=0, ncol=2),
+                        date_cut_m = matrix(nrow = 0, ncol = 2),
                         no_cut_v = vector(),
                         dataset_cut,
                         cut_var,
                         special_dm = TRUE) {
-
   #  Assertions for input parameters -----------------------------------------------
   assert_that(is.list(source_sdtm_data),
     msg = "source_sdtm_data must be a list"
@@ -94,29 +93,30 @@ no_cut_v empty, in which case a default value of vector() will be used."
         patient_cut_v, date_cut_m[, 1], no_cut_v,
         "dm"
       )),
-      msg = "Inconsistency between input SDTMv datasets and the SDTMv datasets listed under each cut approach.
-Please check for the two likely issues below... \n
+      msg = "Inconsistency between input SDTMv datasets and the SDTMv datasets
+listed under each cut approach. Please check for the two likely issues below... \n
 1) There are input SDTMv datasets where no cut method has been defined.
-2) A cut method has been defined for a SDTMv dataset that does not exist in the source SDTMv data."
+2) A cut method has been defined for a SDTMv dataset that does not exist in the
+source SDTMv data."
     )
     assert_that(
       length(unique(c(patient_cut_v, date_cut_m[, 1], no_cut_v, "dm")))
       == length(c(patient_cut_v, date_cut_m[, 1], no_cut_v, "dm")),
-      msg = "The number of SDTMv datasets in the source data does not match the number of SDTMv datasets in
-which a cut approach has been defined."
+      msg = "The number of SDTMv datasets in the source data does not match the
+number of SDTMv datasets in which a cut approach has been defined."
     )
   } else {
     assert_that(setequal(names(source_sdtm_data), c(patient_cut_v, date_cut_m[, 1], no_cut_v)),
-      msg = "Inconsistency between input SDTMv datasets and the SDTMv datasets listed under each cut approach.
-Please check for the two likely issues below... \n
+      msg = "Inconsistency between input SDTMv datasets and the SDTMv datasets
+listed under each cut approach. Please check for the two likely issues below... \n
 1) There are input SDTMv datasets where no cut method has been defined.
 2) A cut method has been defined for a SDTMv dataset that does not exist in the source SDTMv data."
     )
     assert_that(
       length(unique(c(patient_cut_v, date_cut_m[, 1], no_cut_v)))
       == length(c(patient_cut_v, date_cut_m[, 1], no_cut_v)),
-      msg = "The number of SDTMv datasets in the source data does not match the number of SDTMv datasets in
-which a cut approach has been defined."
+      msg = "The number of SDTMv datasets in the source data does not match the
+number of SDTMv datasets in which a cut approach has been defined."
     )
   }
 

--- a/man/process_cut.Rd
+++ b/man/process_cut.Rd
@@ -66,5 +66,6 @@ cut_data <- process_cut(
   cut_var = DCUTDTM,
   special_dm = FALSE
 )
+
 }
 \keyword{derive}

--- a/tests/testthat/test-process_cut.R
+++ b/tests/testthat/test-process_cut.R
@@ -83,9 +83,11 @@ test_that("Test that every type of datacut gives the expected result, when speci
   )
 })
 
-# Test that process_cut() errors when a source SDTM dataset is not referenced in any input list -----------
+# Test that process_cut() errors when a source SDTM dataset is not referenced
+# in any input list
 
-test_that("Test that process_cut() errors when a source SDTM dataset is not referenced in any input list", {
+test_that("Test that process_cut() errors when a source SDTM dataset is not
+          referenced in any input list", {
   expect_error(
     process_cut(
       source_sdtm_data = source_data,
@@ -99,13 +101,16 @@ test_that("Test that process_cut() errors when a source SDTM dataset is not refe
       cut_var = DCUTDTM,
       special_dm = TRUE
     ),
-    regexp = "Inconsistency between input SDTMv datasets and the SDTMv datasets listed under each cut approach."
+    regexp = "Inconsistency between input SDTMv datasets and the SDTMv datasets
+listed under each cut approach."
   )
 })
 
-# Test that process_cut() errors when an input list includes a source SDTMv dataset that does not exist -----------
+# Test that process_cut() errors when an input list includes a source SDTMv
+# dataset that does not exist
 
-test_that("Test that process_cut() errors when an input list includes a source SDTMv dataset that does not exist in the source SDTMv data", {
+test_that("Test that process_cut() errors when an input list includes a source
+           SDTMv dataset that does not exist in the source SDTMv data", {
   expect_error(
     process_cut(
       source_sdtm_data = source_data,
@@ -119,13 +124,16 @@ test_that("Test that process_cut() errors when an input list includes a source S
       cut_var = DCUTDTM,
       special_dm = TRUE
     ),
-    regexp = "Inconsistency between input SDTMv datasets and the SDTMv datasets listed under each cut approach."
+    regexp = "Inconsistency between input SDTMv datasets and the SDTMv datasets
+listed under each cut approach."
   )
 })
 
-# Test that process_cut() errors when a source SDTMv dataset is referenced in more than one input list -----------
+# Test that process_cut() errors when a source SDTMv dataset is referenced in
+# more than one input list
 
-test_that("Test that process_cut() errors when a source SDTMv dataset is referenced in more than one input list", {
+test_that("Test that process_cut() errors when a source SDTMv dataset is
+          referenced in more than one input list", {
   expect_error(
     process_cut(
       source_sdtm_data = source_data,
@@ -139,14 +147,16 @@ test_that("Test that process_cut() errors when a source SDTMv dataset is referen
       cut_var = DCUTDTM,
       special_dm = TRUE
     ),
-    regexp = "The number of SDTMv datasets in the source data does not match the number of SDTMv datasets in
-which a cut approach has been defined."
+    regexp = "The number of SDTMv datasets in the source data does not match the
+number of SDTMv datasets in which a cut approach has been defined."
   )
 })
 
-# Test that process_cut() errors when special_dm = TRUE and dm is also referenced in an input list -----------
+# Test that process_cut() errors when special_dm = TRUE and dm is also referenced
+# in an input list
 
-test_that("Test that process_cut() errors when special_dm = TRUE and dm is also referenced in an input list", {
+test_that("Test that process_cut() errors when special_dm = TRUE and dm is also
+          referenced in an input list", {
   expect_error(
     process_cut(
       source_sdtm_data = source_data,
@@ -160,8 +170,8 @@ test_that("Test that process_cut() errors when special_dm = TRUE and dm is also 
       cut_var = DCUTDTM,
       special_dm = TRUE
     ),
-    regexp = "The number of SDTMv datasets in the source data does not match the number of SDTMv datasets in
-which a cut approach has been defined."
+    regexp = "The number of SDTMv datasets in the source data does not match the
+number of SDTMv datasets in which a cut approach has been defined."
   )
 })
 


### PR DESCRIPTION
Hello @kieranjmartin and @barnett11,
As per issue #134 - I have added default values for the following function arguments:

- patient_cut_v = vector()
- date_cut_m = matrix(nrow=0, ncol=2)
- no_cut_v = vector()

In the reproducible examples provided in #134, these updates means that your first example should now work because no_cut_v will be set to the default value (an empty vector). However, your second example will still fail since it is expected that no_cut_v is a vector but you have set this to "" here. Hopefully this is clear from the documentation of the function but please let know if you think further updates are required.