### PR TITLE
Closes #181 Assertion added for cut date not to be NULL #181

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.2.3
 Depends: R (>= 3.5)
 Imports:
     admiraldev (>= 0.3.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Depends: R (>= 3.5)
 Imports:
     admiraldev (>= 0.3.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,13 +15,13 @@ and not valid date or `NA`/`""` (#181)
 - Added dependency on `admiraldev` >= 0.3.0 (#173)
 
 ## Documentation
-- Added notes on SDTM compatability (#171)
+- Added notes on SDTM compatibility (#171)
 - Cleaned install packages code format (#177)
-- Fixed broken link to github (#184)
+- Fixed broken link to source (#184)
 - Added report a bug link to site (#182)
 
 ## Various
-- Added CRAN badge to README (#174)
+- Added CRAN badge to site (#174)
 - Pull Request template updated (#192)
 
 # datacutr 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,19 +4,25 @@
 - Added a "Report a bug" link to `{datacutr}` website (#182)
 
 ## Updates of Existing Functions
-- Update to `impute_dcutdtc()`, `create_dcut()`, `date_cut()` and `special_dm_cut()` functions
-to allow for datacut date to be null. In this case, all records for this patient will be 
-kept/left unchanged.
-- Warning added to `process_cut` if expected dataset `dm` is missing
+- Update to `impute_dcutdtc()`, `date_cut()` and `special_dm_cut()` functions to allow for 
+datacut date to be null. In this case, all records for this patient 
+will be kept/left unchanged. (#179, #188, #189, #190)
+- Warning added to `process_cut` if expected dataset `dm` is missing (#172)
+- Warning added to `create_dcut` if cut date being passed as `NULL`, 
+and not valid date or `NA`/`""` (#181)
 
 ## Breaking Changes
-- N/A
+- Added dependency on `admiraldev` >= 0.3.0 (#173)
 
 ## Documentation
-- N/A
+- Added notes on SDTM compatability (#171)
+- Cleaned install packages code format (#177)
+- Fixed broken link to github (#184)
+- Added report a bug link to site (#182)
 
 ## Various
-- Minor documentation updates #171 #173 #177 #184
+- Added CRAN badge to README (#174)
+- Pull Request template updated (#192)
 
 # datacutr 0.1.0
 
@@ -35,5 +41,4 @@ kept/left unchanged.
 
 ## Various
 - N/A
-
 

--- a/R/create_dcut.R
+++ b/R/create_dcut.R
@@ -62,6 +62,11 @@ create_dcut <- function(dataset_ds,
    must be stored in ISO 8601 format."
   )
 
+  # Check that cut date is not NULL
+  assert_that(!is.null(cut_date),
+    msg = "Cut date is NULL, please populate as NA or valid ISO8601 date format"
+  )
+
   # Check that cut_date is in ISO 8601 format
   valid_dtc <- is_valid_dtc(cut_date)
   assert_that(valid_dtc,

--- a/tests/testthat/test-create_dcut.R
+++ b/tests/testthat/test-create_dcut.R
@@ -50,3 +50,17 @@ test_that("One observation in DCUT", {
     expected_dcutna
   )
 })
+
+# Test 3 - Cut date as NULL
+test_that("Cut Date of NULL errors", {
+  expect_error(
+    create_dcut(
+      dataset_ds = input_ds,
+      ds_date_var = DSSTDTC,
+      filter = DSDECOD == "INFORMED CONSENT",
+      cut_date = NULL,
+      cut_description = "Patients with Informed Consent"
+    ),
+    regexp = "Cut date is NULL, please populate as NA or valid ISO8601 date format"
+  )
+})


### PR DESCRIPTION
Thank you for your Pull Request! [admiraldev](https://pharmaverse.github.io/admiraldev/devel/index.html) have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiraldev/main/articles/development_process.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the datacutr codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/main/articles/unit_test_guidance.html#writing-unit-tests-in-admiral-)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/main/articles/programming_strategy.html#deprecation-1)?
- [x] Update to all relevant roxygen headers and examples 
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] Build datacutr site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiral/cran-release/reference/index.html)" page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
