### PR TITLE
Set `insert-tweak-page-hook: false` for docs workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -84,6 +84,7 @@ jobs:
     with:
       r-version: "release"
       skip-multiversion-docs: true
+      insert-tweak-page-hook: false
     secrets:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   linter:


### PR DESCRIPTION
Following the fix from https://github.com/pharmaverse/admiralci/pull/193, this ensures that the docs/pkgdown workflow no longer encounters the error we're seeing today.
