### PR TITLE
Use `main` as default landing page

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -83,8 +83,9 @@ jobs:
     needs: get_r_version
     with:
       r-version: "release"
-      skip-multiversion-docs: true
+      skip-multiversion-docs: false
       insert-tweak-page-hook: false
+      multiversion-docs-landing-page: main
     secrets:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   linter:


### PR DESCRIPTION
Per @barnett11 :

> An observation - our documentation now seems to reflect devel, instead of main - is this intentional? We haven't deployed 0.2 yet, is the documentation off main no longer available with this update?
https://pharmaverse.github.io/datacutr/
https://pharmaverse.github.io/datacutr/main/index.html - this used to point to main but fails now?

This should fix it.
