### PR TITLE
Closes  #222 - Writes test readout files to temporary directory

### DIFF
--- a/R/read_out.R
+++ b/R/read_out.R
@@ -76,7 +76,7 @@ read_out <- function(dcut = NULL,
                      date_cut_data = NULL,
                      dm_cut = NULL,
                      no_cut_list = NULL,
-                     out_path = ".") {
+                     out_path = tempdir()) {
   if (!is.null(dcut)) {
     assert_data_frame(dcut,
       required_vars = exprs(USUBJID, DCUTDTC)

--- a/R/read_out.R
+++ b/R/read_out.R
@@ -17,7 +17,7 @@
 #' @param no_cut_list List of of quoted SDTMv domain names in which no cut should be applied. To be
 #' left blank if no domains are to remain exactly as source.
 #' @param out_path A character vector of file save path for the summary file;
-#' the default corresponds to the working directory, `getwd()`.
+#' the default corresponds to a temporary directory, `tempdir()`.
 #'
 #' @return Returns a .html file summarizing the changes made to data during a datacut.
 #'

--- a/man/read_out.Rd
+++ b/man/read_out.Rd
@@ -10,7 +10,7 @@ read_out(
   date_cut_data = NULL,
   dm_cut = NULL,
   no_cut_list = NULL,
-  out_path = "."
+  out_path = tempdir()
 )
 }
 \arguments{
@@ -32,7 +32,7 @@ the variables DCUT_TEMP_REMOVE and DCUT_TEMP_DTHCHANGE.}
 left blank if no domains are to remain exactly as source.}
 
 \item{out_path}{A character vector of file save path for the summary file;
-the default corresponds to the working directory, \code{getwd()}.}
+the default corresponds to a temporary directory, \code{tempdir()}.}
 }
 \value{
 Returns a .html file summarizing the changes made to data during a datacut.

--- a/tests/testthat/test-process_cut.R
+++ b/tests/testthat/test-process_cut.R
@@ -189,10 +189,10 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = TRUE,
     read_out = TRUE,
-    out_path = paste0(temp_dir,"/dummyfile")
+    out_path = paste0(temp_dir, "/dummyfile")
   )
-  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir,"/dummyfile")))) > 0)
-  unlink(paste0(temp_dir,"/dummyfile"), recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir, "/dummyfile")))) > 0)
+  unlink(paste0(temp_dir, "/dummyfile"), recursive = TRUE)
 })
 
 # Test that every type of datacut gives the expected result, when special_dm=FALSE -----------
@@ -233,8 +233,8 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = FALSE,
     read_out = TRUE,
-    out_path = paste0(temp_dir,"/dummyfile")
+    out_path = paste0(temp_dir, "/dummyfile")
   )
-  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir,"/dummyfile"))) > 0))
-  unlink(paste0(temp_dir,"/dummyfile"), recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir, "/dummyfile"))) > 0))
+  unlink(paste0(temp_dir, "/dummyfile"), recursive = TRUE)
 })

--- a/tests/testthat/test-process_cut.R
+++ b/tests/testthat/test-process_cut.R
@@ -63,6 +63,9 @@ expected <- list(
   ae = ae_cut, lb = lb_cut, ts = ts_cut
 )
 
+# Create temporary directory for testing output file
+temp_dir <- tempdir()
+
 # Test that every type of datacut gives the expected result, when special_dm=TRUE -----------
 
 test_that("Test that every type of datacut gives the expected result, when special_dm=TRUE", {
@@ -186,10 +189,10 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = TRUE,
     read_out = TRUE,
-    out_path = "~/dummyfile"
+    out_path = paste0(temp_dir,"/dummyfile")
   )
-  expect_true(dir.exists("~/dummyfile") & (length(list.files("~/dummyfile")) > 0))
-  unlink("~/dummyfile", recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir,"/dummyfile")))) > 0)
+  unlink(paste0(temp_dir,"/dummyfile"), recursive = TRUE)
 })
 
 # Test that every type of datacut gives the expected result, when special_dm=FALSE -----------
@@ -230,8 +233,8 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = FALSE,
     read_out = TRUE,
-    out_path = "~/dummyfile"
+    out_path = paste0(temp_dir,"/dummyfile")
   )
-  expect_true(dir.exists("~/dummyfile") & (length(list.files("~/dummyfile")) > 0))
-  unlink("~/dummyfile", recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir,"/dummyfile"))) > 0))
+  unlink(paste0(temp_dir,"/dummyfile"), recursive = TRUE)
 })

--- a/tests/testthat/test-read_out.R
+++ b/tests/testthat/test-read_out.R
@@ -70,9 +70,6 @@ dm_cut <- tibble::tribble(
   "AB12345-005", "Y", "2022-12-01", "Y", "2022-12-01", NA, NA
 )
 
-# Create temporary directory for testing output file
-temp_dir <- tempdir()
-
 # Testing ---------------------------------------------------------------------------------------------------------
 
 # Test that .Rmd gives the expected result when all fields are set to default or contain valid data -----------
@@ -85,7 +82,7 @@ test_that("Correct .Rmd file is run successfully when fields contain correct dat
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = temp_dir
+    out_path = tempdir()
   )
   # Assert that the output file is generated successfully
   expect_true(file.exists(result))
@@ -95,7 +92,7 @@ test_that("Correct .Rmd file is run successfully when fields contain correct dat
 # Test that Correct .Rmd file is ran successfully when fields are empty
 test_that("Correct .Rmd file is ran successfully when fields are empty", {
   # Call read_out() to generate the .Rmd file
-  result <- read_out(out_path = temp_dir)
+  result <- read_out(out_path = tempdir())
   # Assert that the output file is generated successfully
   expect_true(file.exists(result))
   unlink(result, recursive = TRUE)
@@ -111,7 +108,7 @@ test_that("Test that read_out() errors dcut data frame does not contain the var 
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = temp_dir
+    out_path = tempdir()
   ))
 })
 
@@ -125,7 +122,7 @@ test_that("Test that read_out() errors when patient_cut_data input is not a list
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "patient_cut_data must be a list. \n
 Note: If you have not used or do not with to view patient cut on any SDTMv domains, then
@@ -141,7 +138,7 @@ test_that("Test that read_out() errors when elements in the patient_cut_data lis
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = temp_dir
+    out_path = tempdir()
   ))
 })
 
@@ -154,7 +151,7 @@ test_that("Test that read_out() errors when data frames in patient_cut_data are 
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "All elements patient_cut_data must be named with corresponding domain"
   )
@@ -170,7 +167,7 @@ test_that("Test that read_out() errors when date_cut_data input is not a list", 
       date_cut_data = ae,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "date_cut_data must be a list. \n
 Note: If you have not used or do not with to view date cut on any SDTMv domains, then please
@@ -186,7 +183,7 @@ test_that("Test that read_out() errors when elements in the date_cut_data list a
     date_cut_data = list("ae", "lb"),
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = temp_dir
+    out_path = tempdir()
   ))
 })
 
@@ -199,7 +196,7 @@ test_that("Test that read_out() errors when data frames in date_cut_data are unn
       date_cut_data = list(ae, lb),
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "All elements in date_cut_data must be named with corresponding domain"
   )
@@ -214,7 +211,7 @@ test_that("Test that read_out() errors when dm_cut data frame does not contain t
     date_cut_data = dt_cut_data,
     dm_cut = sc,
     no_cut_list = no_cut_ls,
-    out_path = temp_dir
+    out_path = tempdir()
   ))
 })
 
@@ -229,7 +226,7 @@ test_that("Test that read_out() errors when no_cut_list is not a list", {
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = ds,
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "no_cut_list must be a list. \n
 Note: If you have not used or do not with to view the SDTMv domains where no cut has been
@@ -246,7 +243,7 @@ test_that("Test that read_out() errors when elements in the no_cut_list list are
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = ls("ts"),
-    out_path = temp_dir
+    out_path = tempdir()
   ))
 })
 
@@ -259,7 +256,7 @@ test_that("Test that read_out() errors when elements in the no_cut_list list are
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = list(ts, ae),
-      out_path = temp_dir
+      out_path = tempdir()
     ),
     regexp = "All elements in no_cut_list must be named with corresponding domain"
   )

--- a/tests/testthat/test-read_out.R
+++ b/tests/testthat/test-read_out.R
@@ -70,6 +70,9 @@ dm_cut <- tibble::tribble(
   "AB12345-005", "Y", "2022-12-01", "Y", "2022-12-01", NA, NA
 )
 
+# Create temporary directory for testing output file
+temp_dir <- tempdir()
+
 # Testing ---------------------------------------------------------------------------------------------------------
 
 # Test that .Rmd gives the expected result when all fields are set to default or contain valid data -----------
@@ -82,7 +85,7 @@ test_that("Correct .Rmd file is run successfully when fields contain correct dat
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = "."
+    out_path = temp_dir
   )
   # Assert that the output file is generated successfully
   expect_true(file.exists(result))
@@ -92,7 +95,7 @@ test_that("Correct .Rmd file is run successfully when fields contain correct dat
 # Test that Correct .Rmd file is ran successfully when fields are empty
 test_that("Correct .Rmd file is ran successfully when fields are empty", {
   # Call read_out() to generate the .Rmd file
-  result <- read_out()
+  result <- read_out(out_path = temp_dir)
   # Assert that the output file is generated successfully
   expect_true(file.exists(result))
   unlink(result, recursive = TRUE)
@@ -108,7 +111,7 @@ test_that("Test that read_out() errors dcut data frame does not contain the var 
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = "."
+    out_path = temp_dir
   ))
 })
 
@@ -122,7 +125,7 @@ test_that("Test that read_out() errors when patient_cut_data input is not a list
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "patient_cut_data must be a list. \n
 Note: If you have not used or do not with to view patient cut on any SDTMv domains, then
@@ -138,7 +141,7 @@ test_that("Test that read_out() errors when elements in the patient_cut_data lis
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = "."
+    out_path = temp_dir
   ))
 })
 
@@ -151,7 +154,7 @@ test_that("Test that read_out() errors when data frames in patient_cut_data are 
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "All elements patient_cut_data must be named with corresponding domain"
   )
@@ -167,7 +170,7 @@ test_that("Test that read_out() errors when date_cut_data input is not a list", 
       date_cut_data = ae,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "date_cut_data must be a list. \n
 Note: If you have not used or do not with to view date cut on any SDTMv domains, then please
@@ -183,7 +186,7 @@ test_that("Test that read_out() errors when elements in the date_cut_data list a
     date_cut_data = list("ae", "lb"),
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = "."
+    out_path = temp_dir
   ))
 })
 
@@ -196,7 +199,7 @@ test_that("Test that read_out() errors when data frames in date_cut_data are unn
       date_cut_data = list(ae, lb),
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "All elements in date_cut_data must be named with corresponding domain"
   )
@@ -211,7 +214,7 @@ test_that("Test that read_out() errors when dm_cut data frame does not contain t
     date_cut_data = dt_cut_data,
     dm_cut = sc,
     no_cut_list = no_cut_ls,
-    out_path = "."
+    out_path = temp_dir
   ))
 })
 
@@ -226,7 +229,7 @@ test_that("Test that read_out() errors when no_cut_list is not a list", {
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = ds,
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "no_cut_list must be a list. \n
 Note: If you have not used or do not with to view the SDTMv domains where no cut has been
@@ -243,7 +246,7 @@ test_that("Test that read_out() errors when elements in the no_cut_list list are
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = ls("ts"),
-    out_path = "."
+    out_path = temp_dir
   ))
 })
 
@@ -256,7 +259,7 @@ test_that("Test that read_out() errors when elements in the no_cut_list list are
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = list(ts, ae),
-      out_path = "."
+      out_path = temp_dir
     ),
     regexp = "All elements in no_cut_list must be named with corresponding domain"
   )


### PR DESCRIPTION
Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/CONTRIBUTING.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the datacutr codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [x] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] Build datacutr site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/datacutr/main/reference/index.html)" page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
