### PR TITLE
Disable coverage reporting as it's unused

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -110,7 +110,7 @@ jobs:
       # Whether to skip code coverage badge creation
       # Setting to 'false' will require you to create
       # an orphan branch called 'badges' in your repository
-      skip-coverage-badges: false
+      skip-coverage-badges: true
   man-pages:
     name: Man Pages
     uses: pharmaverse/admiralci/.github/workflows/man-pages.yml@main


### PR DESCRIPTION
The code coverage badge seems to have been derived from elsewhere here: https://github.com/pharmaverse/datacutr/blob/devel/README.md?plain=1#L11

Fixes #226 