### PR TITLE
Closes #230 - debian issues

### DIFF
--- a/tests/testthat/test-process_cut.R
+++ b/tests/testthat/test-process_cut.R
@@ -63,9 +63,6 @@ expected <- list(
   ae = ae_cut, lb = lb_cut, ts = ts_cut
 )
 
-# Create temporary directory for testing output file
-temp_dir <- tempdir()
-
 # Test that every type of datacut gives the expected result, when special_dm=TRUE -----------
 
 test_that("Test that every type of datacut gives the expected result, when special_dm=TRUE", {
@@ -177,6 +174,9 @@ test_that("Test that process_cut() errors when special_dm = TRUE and dm is also
 # Test Read-out file -------------
 # Test that read-out file is ran successfully when special_dm = TRUE
 test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
+  # Run test
   process_cut(
     source_sdtm_data = source_data,
     patient_cut_v = c("sc", "ds"),
@@ -189,10 +189,10 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = TRUE,
     read_out = TRUE,
-    out_path = paste0(temp_dir, "/dummyfile")
+    out_path = paste0(temp_dir)
   )
-  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir, "/dummyfile")))) > 0)
-  unlink(paste0(temp_dir, "/dummyfile"), recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(temp_dir))) > 0)
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that every type of datacut gives the expected result, when special_dm=FALSE -----------
@@ -221,6 +221,9 @@ test_that("Test that every type of datacut gives the expected result, when speci
 
 # Test that Read-out file is ran successfully when special_dm = FALSE
 test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
+  # Run test
   process_cut(
     source_sdtm_data = source_data,
     patient_cut_v = c("sc", "ds"),
@@ -233,8 +236,8 @@ test_that("Test that Correct .Rmd file is ran successfully when read_out = TRUE"
     cut_var = DCUTDTM,
     special_dm = FALSE,
     read_out = TRUE,
-    out_path = paste0(temp_dir, "/dummyfile")
+    out_path = temp_dir
   )
-  expect_true(dir.exists(temp_dir) & (length(list.files(paste0(temp_dir, "/dummyfile"))) > 0))
-  unlink(paste0(temp_dir, "/dummyfile"), recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(temp_dir)) > 0))
+  unlink(temp_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-read_out.R
+++ b/tests/testthat/test-read_out.R
@@ -75,6 +75,8 @@ dm_cut <- tibble::tribble(
 # Test that .Rmd gives the expected result when all fields are set to default or contain valid data -----------
 # Correct .Rmd file is run successfully when fields contain correct data inputs
 test_that("Correct .Rmd file is run successfully when fields contain correct data inputs", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   # Call read_out() to generate the .Rmd file
   result <- read_out(
     dcut = dcut,
@@ -82,39 +84,46 @@ test_that("Correct .Rmd file is run successfully when fields contain correct dat
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = tempdir()
+    out_path = temp_dir
   )
   # Assert that the output file is generated successfully
-  expect_true(file.exists(result))
-  unlink(result, recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(temp_dir))) > 0)
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that Correct .Rmd file is ran successfully when fields are empty
 test_that("Correct .Rmd file is ran successfully when fields are empty", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   # Call read_out() to generate the .Rmd file
-  result <- read_out(out_path = tempdir())
+  result <- read_out(out_path = temp_dir)
   # Assert that the output file is generated successfully
-  expect_true(file.exists(result))
-  unlink(result, recursive = TRUE)
+  expect_true(dir.exists(temp_dir) & (length(list.files(temp_dir))) > 0)
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test read_out() errors when data cut fields are incorrect input types -----------
 ## DCUT ----
 # Test that read_out() errors dcut data frame does not contain the var DCUTDTC
 test_that("Test that read_out() errors dcut data frame does not contain the var DCUTDTC", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(read_out(
     dcut = sc,
     patient_cut_data = pt_cut_data,
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = tempdir()
+    out_path = temp_dir
   ))
+  unlink(temp_dir, recursive = TRUE)
 })
 
 ## Patient_cut_data ----
 # Test that read_out() errors when patient_cut_data input is not a list
 test_that("Test that read_out() errors when patient_cut_data input is not a list", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -122,28 +131,34 @@ test_that("Test that read_out() errors when patient_cut_data input is not a list
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "patient_cut_data must be a list. \n
 Note: If you have not used or do not with to view patient cut on any SDTMv domains, then
 please leave patient_cut_data empty, in which case a default value of NULL will be used."
   )
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when elements in the patient_cut_data list are not data frames
 test_that("Test that read_out() errors when elements in the patient_cut_data list are not data frames", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(read_out(
     dcut = dcut,
     patient_cut_data = list("sc", "ds"),
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = tempdir()
+    out_path = temp_dir
   ))
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when data frames in patient_cut_data are unnamed
 test_that("Test that read_out() errors when data frames in patient_cut_data are unnamed", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -151,15 +166,18 @@ test_that("Test that read_out() errors when data frames in patient_cut_data are 
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "All elements patient_cut_data must be named with corresponding domain"
   )
+  unlink(temp_dir, recursive = TRUE)
 })
 
 ## Date_cut_data ----
 # Test that read_out() errors when date_cut_data input is not a list
 test_that("Test that read_out() errors when date_cut_data input is not a list", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -167,28 +185,34 @@ test_that("Test that read_out() errors when date_cut_data input is not a list", 
       date_cut_data = ae,
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "date_cut_data must be a list. \n
 Note: If you have not used or do not with to view date cut on any SDTMv domains, then please
 leave date_cut_data empty, in which case a default value of NULL will be used."
   )
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when elements in the date_cut_data list are not data frames
 test_that("Test that read_out() errors when elements in the date_cut_data list are not data frames", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(read_out(
     dcut = dcut,
     patient_cut_data = pt_cut_data,
     date_cut_data = list("ae", "lb"),
     dm_cut = dm_cut,
     no_cut_list = no_cut_ls,
-    out_path = tempdir()
+    out_path = temp_dir
   ))
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when data frames in date_cut_data are unnamed
 test_that("Test that read_out() errors when data frames in date_cut_data are unnamed", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -196,29 +220,35 @@ test_that("Test that read_out() errors when data frames in date_cut_data are unn
       date_cut_data = list(ae, lb),
       dm_cut = dm_cut,
       no_cut_list = no_cut_ls,
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "All elements in date_cut_data must be named with corresponding domain"
   )
+  unlink(temp_dir, recursive = TRUE)
 })
 
 ## dm_cut ----
 # Test that read_out() errors when dm_cut data frame does not contain the vars DCUT_TEMP_REMOVE & DCUT_TEMP_DTHCHANG
 test_that("Test that read_out() errors when dm_cut data frame does not contain the vars DCUT_TEMP_REMOVE & DCUT_TEMP_DTHCHANGE", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(read_out(
     dcut = dcut,
     patient_cut_data = pt_cut_data,
     date_cut_data = dt_cut_data,
     dm_cut = sc,
     no_cut_list = no_cut_ls,
-    out_path = tempdir()
+    out_path = temp_dir
   ))
+  unlink(temp_dir, recursive = TRUE)
 })
 
 
 ## no_cut_list ----
 # Test that read_out() errors when no_cut_list is not a list
 test_that("Test that read_out() errors when no_cut_list is not a list", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -226,29 +256,35 @@ test_that("Test that read_out() errors when no_cut_list is not a list", {
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = ds,
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "no_cut_list must be a list. \n
 Note: If you have not used or do not with to view the SDTMv domains where no cut has been
 applied, then please leave no_cut_list empty, in which case a default value of NULL will be
 used."
   )
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when elements in the no_cut_list list are not data frames
 test_that("Test that read_out() errors when elements in the no_cut_list list are not data frames", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(read_out(
     dcut = dcut,
     patient_cut_data = pt_cut_data,
     date_cut_data = dt_cut_data,
     dm_cut = dm_cut,
     no_cut_list = ls("ts"),
-    out_path = tempdir()
+    out_path = temp_dir
   ))
+  unlink(temp_dir, recursive = TRUE)
 })
 
 # Test that read_out() errors when elements in the no_cut_list list are not named with the corresponding domain
 test_that("Test that read_out() errors when elements in the no_cut_list list are not named with the corresponding domain", {
+  # Create temporary directory for testing output file
+  temp_dir <- tempdir()
   expect_error(
     read_out(
       dcut = dcut,
@@ -256,8 +292,9 @@ test_that("Test that read_out() errors when elements in the no_cut_list list are
       date_cut_data = dt_cut_data,
       dm_cut = dm_cut,
       no_cut_list = list(ts, ae),
-      out_path = tempdir()
+      out_path = temp_dir
     ),
     regexp = "All elements in no_cut_list must be named with corresponding domain"
   )
+  unlink(temp_dir, recursive = TRUE)
 })


### PR DESCRIPTION
Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/CONTRIBUTING.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the datacutr codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [ ] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [ ] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [ ] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Address any updates needed for vignettes and/or templates
- [ ] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [ ] Build datacutr site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/datacutr/main/reference/index.html)" page. 
- [ ] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [ ] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [ ] Link the issue in the Development Section on the right hand side.
- [ ] Address all merge conflicts and resolve appropriately 
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
