### PR TITLE
Remove lintr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     reactable (>= 0.4.4)
 Suggests:
     devtools,
-    lintr,
     pkgdown,
     testthat,
     knitr,
@@ -45,3 +44,4 @@ Suggests:
     usethis,
     covr
 VignetteBuilder: knitr
+Config/wants/development: lintr


### PR DESCRIPTION
Since {lintr} is not needed for the package on CRAN, it's best to remove this entry.

The specific key `Config/wants/development` is somewhat experimental, but contrasts with `Config/needs/development`, which would be "absolutely required to develop the package", which is useful for building minimal docker images, e.g.