### PR TITLE
Closes #273 - Prepare for v1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datacutr
 Type: Package
 Title: SDTM Datacut
-Version: 0.2.4
+Version: 1.0.0
 Authors@R: c(
     person("Tim", "Barnett", email = "timothy.barnett@roche.com", role = c("cph","aut", "cre")), 
     person("Nathan", "Rees", email = "nathan.rees@roche.com", role = c("aut")), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,3 +46,4 @@ Suggests:
 VignetteBuilder: knitr
 Config/wants/development: lintr
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# datacutr 1.0.0
+
+## Updates of Existing Functions
+- `read_out` updated to resolve relative path to absolute in `out_path`
+
+## Various
+
+- Clarifies imputation approach for death dates in documentation
+
 # datacutr 0.2.4
 
 ## Updates of Existing Functions

--- a/R/apply_cut.R
+++ b/R/apply_cut.R
@@ -50,14 +50,14 @@ apply_cut <- function(dsin, dcutvar, dthchangevar) {
     )
 
     # Remove any rows where datacut flagging variable (dcutvar) is "Y"
-    out <- dsin %>%
+    out <- dsin |>
       filter(is.na(!!dcutvar) | !!dcutvar != "Y")
 
     # Overwrite death variables if death change variable (dthchangevar) is "Y"
     if (any(names(dsin) == expr_name(dthchangevar))) {
       assert_symbol(dthchangevar)
       if (any(names(dsin) == "DTHFL")) {
-        out <- out %>%
+        out <- out |>
           mutate(DTHFL = case_when(
             as.character(!!dthchangevar) == "Y" ~ NA_character_,
             TRUE ~ as.character(DTHFL)
@@ -65,7 +65,7 @@ apply_cut <- function(dsin, dcutvar, dthchangevar) {
         attributes(out$DTHFL)$label <- attributes(dsin$DTHFL)$label
       }
       if (any(names(dsin) == "DTHDTC")) {
-        out <- out %>%
+        out <- out |>
           mutate(DTHDTC = case_when(
             as.character(!!dthchangevar) == "Y" ~ NA_character_,
             TRUE ~ as.character(DTHDTC)

--- a/R/drop_temp_vars.R
+++ b/R/drop_temp_vars.R
@@ -40,12 +40,12 @@ drop_temp_vars <- function(dsin, drop_dcut_temp = TRUE) {
     msg = "drop_dcut_temp must be either TRUE or FALSE"
   )
 
-  out <- dsin %>%
+  out <- dsin |>
     select(-starts_with("TEMP_"))
 
   if (drop_dcut_temp) {
-    out <- out %>%
+    out <- out |>
       select(-starts_with("DCUT_TEMP_"))
   }
-  return(out)
+  out
 }

--- a/R/impute_dcutdtc.R
+++ b/R/impute_dcutdtc.R
@@ -111,7 +111,7 @@ impute_dcutdtc <- function(dsin, varin, varout) {
   imputed_dtc_final <- gsub("\\..*", "", imputed_dtc_2)
 
   # Add our new imputed datetime variable back to dsin + convert to datetime object
-  out <- dsin %>%
+  out <- dsin |>
     mutate(!!varout := ymd_hms(imputed_dtc_final))
 
   # Drop temporary variables

--- a/R/impute_sdtm.R
+++ b/R/impute_sdtm.R
@@ -112,7 +112,7 @@ impute_sdtm <- function(dsin, varin, varout) {
   imputed_dtc_final <- gsub("\\..*", "", imputed_dtc_2)
 
   # Add our new imputed datetime variable back to dsin + convert to datetime object
-  out <- dsin %>%
+  out <- dsin |>
     mutate(!!varout := ymd_hms(imputed_dtc_final))
 
   # Drop temporary variables

--- a/R/pt_cut.R
+++ b/R/pt_cut.R
@@ -51,8 +51,8 @@ pt_cut <- function(dataset_sdtm,
     msg = "Duplicate patients in the DCUT (dataset_cut) dataset, please update."
   )
 
-  dcut <- dataset_cut %>%
-    subset(select = c(USUBJID)) %>%
+  dcut <- dataset_cut |>
+    subset(select = c(USUBJID)) |>
     mutate(TEMP_FLAG = "Y")
 
   attributes(dcut$USUBJID)$label <- attributes(dataset_sdtm$USUBJID)$label
@@ -72,7 +72,7 @@ pt_cut <- function(dataset_sdtm,
       )
 
     # Flag records to be removed - patients not in dcut dataset
-    dataset <- dataset_sdtm_pt %>%
+    dataset <- dataset_sdtm_pt |>
       mutate(DCUT_TEMP_REMOVE = ifelse(is.na(TEMP_FLAG), "Y", NA_character_))
 
     dataset <- drop_temp_vars(dsin = dataset, drop_dcut_temp = FALSE)

--- a/R/special_dm_cut.R
+++ b/R/special_dm_cut.R
@@ -69,9 +69,9 @@ special_dm_cut <- function(dataset_dm,
     dm_temp <- pt_cut(
       dataset_sdtm = dataset_dm,
       dataset_cut = dataset_cut
-    ) %>%
-      impute_sdtm(DTHDTC, DCUT_TEMP_DTHDT) %>%
-      left_join((dataset_cut %>% select(USUBJID, DCUT_TEMP_DCUTDTM = !!cut_var)),
+    ) |>
+      impute_sdtm(DTHDTC, DCUT_TEMP_DTHDT) |>
+      left_join((dataset_cut |> select(USUBJID, DCUT_TEMP_DCUTDTM = !!cut_var)),
         by = "USUBJID"
       )
 
@@ -80,7 +80,7 @@ special_dm_cut <- function(dataset_dm,
     ), NA)
 
     # Flag records with Death Date after Cut date
-    dataset_updatedth <- dm_temp %>%
+    dataset_updatedth <- dm_temp |>
       mutate(DCUT_TEMP_DTHCHANGE = case_when(
         !is.na(DCUT_TEMP_DCUTDTM) & (DCUT_TEMP_DTHDT > DCUT_TEMP_DCUTDTM) ~ "Y",
         TRUE ~ as.character(NA)

--- a/inst/read-out/read_out.Rmd
+++ b/inst/read-out/read_out.Rmd
@@ -147,7 +147,7 @@ df_tabs <- function(data) {
       cat(paste("Number of records removed in DM: ", x, " \n"))
       y <- length(which(data$DCUT_TEMP_DTHCHANGE == "Y"))
       cat(paste("Number of records modified in DM: ", y, " \n", " \n"))
-      removed <- data %>% filter(data$DCUT_TEMP_REMOVE == "Y" | data$DCUT_TEMP_DTHCHANGE == "Y")
+      removed <- data |> filter(data$DCUT_TEMP_REMOVE == "Y" | data$DCUT_TEMP_DTHCHANGE == "Y")
       print(htmltools::tagList(reactable(removed,
         rowStyle = function(index) {
           row <- removed[index, ]
@@ -172,7 +172,7 @@ df_tabs <- function(data) {
         cat("####", toupper(name), " \n")
         x <- length(which(df$DCUT_TEMP_REMOVE == "Y"))
         cat(paste("Number of records removed in ", toupper(name), ": ", x, " \n", " \n"))
-        removed <- df %>% filter(df$DCUT_TEMP_REMOVE == "Y")
+        removed <- df |> filter(df$DCUT_TEMP_REMOVE == "Y")
         print(htmltools::tagList(reactable(removed,
           bordered = TRUE, filterable = TRUE, searchable = TRUE, pagination = TRUE,
           showPageSizeOptions = TRUE, showSortable = TRUE,
@@ -215,7 +215,7 @@ sum_test <- function(data) {
         `After Cut` = numeric(),
         Removed = numeric(),
         Modified = numeric()
-      ) %>%
+      ) |>
         add_row(Dataset = "DM", `Before Cut` = uncut, `After Cut` = cut, Removed = x, Modified = y)
       print(htmltools::tagList(reactable(sum_t,
         columnGroups = list(

--- a/man/datacutr-package.Rd
+++ b/man/datacutr-package.Rd
@@ -24,7 +24,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Tim Barnett \email{timothy.barnett@roche.com} [copyright holder]
   \item Nathan Rees \email{nathan.rees@roche.com}
   \item Alana Harris \email{alana.harris@roche.com}
   \item Cara Andrews \email{cara.andrews@roche.com}

--- a/man/datacutr-package.Rd
+++ b/man/datacutr-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Tim Barnett \email{timothy.barnett@roche.com} [copyright holder]
   \item Nathan Rees \email{nathan.rees@roche.com}
   \item Alana Harris \email{alana.harris@roche.com}
   \item Cara Andrews \email{cara.andrews@roche.com}

--- a/vignettes/datacutr.Rmd
+++ b/vignettes/datacutr.Rmd
@@ -52,7 +52,7 @@ Any SDTMv records where the chosen SDTMv date/time variable is missing (or is mi
 All other partial date/times are imputed to the minimum possible date/time, i.e; we impute with 01 for missing month, 01 for missing day, 00 for missing hours, 00 for missing minutes, and 00 for missing seconds.  
 By imputing any missing components of the data cutoff date/time to their maximum possible value and any missing components of the SDTMv date/time variable to their minimum possible value, we ensure that a record is only cut if it is clear that the SDTMv date/time variable is after the data cutoff date/time.  
 - Handling of Deaths  
-For deaths, the derived DM death information is updated to reflect the state at the time of the data cutoff date. The Death Flag (DM.DTHFL) and associated variables (e.g., DM.DTHDT) are set to missing if the subject died after the data cutoff date.
+For deaths, the derived DM death information is updated to reflect the state at the time of the data cutoff date. The Death Flag (DM.DTHFL) and associated variables (e.g., DM.DTHDTC) are set to missing if the subject died after the data cutoff date.
 The handling of partial death dates is the same as set out in the previous "Missing or Partial Date/Times" section when 
 comparing to data cutoff date.
 

--- a/vignettes/datacutr.Rmd
+++ b/vignettes/datacutr.Rmd
@@ -53,6 +53,8 @@ All other partial date/times are imputed to the minimum possible date/time, i.e;
 By imputing any missing components of the data cutoff date/time to their maximum possible value and any missing components of the SDTMv date/time variable to their minimum possible value, we ensure that a record is only cut if it is clear that the SDTMv date/time variable is after the data cutoff date/time.  
 - Handling of Deaths  
 For deaths, the derived DM death information is updated to reflect the state at the time of the data cutoff date. The Death Flag (DM.DTHFL) and associated variables (e.g., DM.DTHDT) are set to missing if the subject died after the data cutoff date.
+The handling of partial death dates is the same as set out in the previous "Missing or Partial Date/Times" section when 
+comparing to data cutoff date.
 
 # Validation
 

--- a/vignettes/examplemodular.Rmd
+++ b/vignettes/examplemodular.Rmd
@@ -55,7 +55,7 @@ dcut <- create_dcut(
 # Pre-processing of FA ----------------------------------------------------
 
 # Update FA
-source_data$fa <- source_data$fa %>%
+source_data$fa <- source_data$fa |>
   mutate(DCUT_TEMP_FAXDTC = case_when(
     FASTDTC != "" ~ FASTDTC,
     FADTC != "" ~ FADTC,

--- a/vignettes/examplewrapped.Rmd
+++ b/vignettes/examplewrapped.Rmd
@@ -58,7 +58,7 @@ dcut <- create_dcut(
 # Pre-processing of FA ----------------------------------------------------
 
 # Update FA
-source_data$fa <- source_data$fa %>%
+source_data$fa <- source_data$fa |>
   mutate(DCUT_TEMP_FAXDTC = case_when(
     FASTDTC != "" ~ FASTDTC,
     FADTC != "" ~ FADTC,

--- a/vignettes/modular.Rmd
+++ b/vignettes/modular.Rmd
@@ -75,7 +75,7 @@ dataset_vignette(
 ## Preprocess Datasets {#preprocess}
 If any pre-processing of datasets is needed, for example in the case of FA, where there are multiple date variables, this should be done next. 
 ```{r, message=FALSE, warning=FALSE}
-source_data$fa <- source_data$fa %>%
+source_data$fa <- source_data$fa |>
   mutate(DCUT_TEMP_FAXDTC = case_when(
     FASTDTC != "" ~ FASTDTC,
     FADTC != "" ~ FADTC,

--- a/vignettes/variable_cut.Rmd
+++ b/vignettes/variable_cut.Rmd
@@ -79,10 +79,10 @@ sv <- tibble::tribble(
   "AB12345-004", "WEEK24", "2022-05-04",
 )
 
-dcut <- dcut %>%
-  left_join(sv %>%
-    filter(VISIT == "WEEK24") %>%
-    select(USUBJID, SVSTDTC)) %>%
+dcut <- dcut |>
+  left_join(sv |>
+    filter(VISIT == "WEEK24") |>
+    select(USUBJID, SVSTDTC)) |>
   mutate(DCUTDTC = as.character(ifelse(!is.na(SVSTDTC), SVSTDTC, as.character(DCUTDTC)))) %>%
   impute_dcutdtc(dsin = ., varin = DCUTDTC, varout = DCUTDTM)
 ```

--- a/vignettes/wrapper.Rmd
+++ b/vignettes/wrapper.Rmd
@@ -73,7 +73,7 @@ dataset_vignette(
 If any pre-processing of SDTM datasets is needed, this should be done next. For example, in the case of FA, where both FASTDTC and FADTC date variables are used, we can combine these into one date variable.  
 
 ```{r, message=FALSE, warning=FALSE}
-source_data$fa <- source_data$fa %>%
+source_data$fa <- source_data$fa |>
   mutate(DCUT_TEMP_FAXDTC = case_when(
     FASTDTC != "" ~ FASTDTC,
     FADTC != "" ~ FADTC,


### PR DESCRIPTION
Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/CONTRIBUTING.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the datacutr codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [x] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] Build datacutr site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/datacutr/main/reference/index.html)" page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
